### PR TITLE
Make TimeOfDay timezone aware - closes #1111

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/devcontainers/base:debian
+
+# ---
+# Add testing repo to get latest versions of tools
+COPY <<EOF /etc/apt/sources.list.d/testing.list
+deb http://deb.debian.org/debian testing main
+EOF
+
+# ---
+# Install Python 3.12
+RUN apt update \
+&& apt install -y --no-install-recommends python3.12-full python3-pip \
+&& rm -rf /var/lib/apt/lists/* \
+&& rm /etc/apt/sources.list.d/testing.list
+
+# ---
+# Install tools needed for building docs
+RUN apt update \
+&& apt install -y --no-install-recommends \
+    graphviz \
+    inkscape \
+    latexmk \
+    texlive-fonts-recommended \
+    texlive-latex-recommended \
+    texlive-latex-extra \
+    texlive-xetex \
+    xindy \
+&& rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "gpiozero",
+    "build": {"dockerfile": "Dockerfile"},
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": ".devcontainer/.venv/bin/python3"
+            }
+        }
+    },
+
+    "postCreateCommand": ".devcontainer/postcreate.sh",
+    "postAttachCommand": ". .devcontainer/.venv/bin/activate"
+}

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -1,0 +1,4 @@
+rm -rf .devcontainer/.venv
+python3.12 -m venv .devcontainer/.venv
+. .devcontainer/.venv/bin/activate
+make develop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
           - os: ubuntu-22.04
             python: "3.11"
             experimental: false
+          - os: ubuntu-22.04
+            python: "3.12"
+            experimental: false
 
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,7 @@
 
 name: Python package
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -43,4 +39,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest -v -k 'not test_real_pins.py'
+        pytest -v -k 'not test_real_pins.py' --cov
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 # Python stuff
 *.py[cdo]
+.venv
 
 # Editor detritus
 *.vim
 *.swp
+.vscode
+*.code-workspace
 tags
 
 # Packaging detritus

--- a/docs/compat.rst
+++ b/docs/compat.rst
@@ -140,7 +140,7 @@ no longer supported (in practice, this means Python 2.7 is no longer
 supported). If your code is not compatible with Python 3, you should follow the
 `porting guide`_ in the `Python documentation`_.
 
-As of GPIO Zero 2.0, the lowest supported Python version will be 3.5. This base
+Currently, the lowest supported Python version is be 3.9. This base
 version may advance with minor releases, but we will make a reasonable best
 effort not to break compatibility with old Python 3.x versions, and to ensure
 that GPIO Zero can run on the version of Python in Debian oldstable at the

--- a/gpiozero/devices.py
+++ b/gpiozero/devices.py
@@ -16,7 +16,6 @@ import warnings
 from collections import namedtuple
 from itertools import chain
 from types import FunctionType
-from importlib.metadata import entry_points
 
 from .threads import _threads_shutdown
 from .mixins import (
@@ -34,6 +33,8 @@ from .exc import (
     NativePinFactoryFallback,
     PinFactoryFallback,
 )
+
+from .ep import PinFactory_entry_points
 
 from .compat import frozendict
 
@@ -300,15 +301,10 @@ class Device(ValuesMixin, GPIOBase):
             # entry-point. Try with name verbatim first. If that fails, attempt
             # with the lower-cased name (this ensures compatibility names work
             # but we're still case insensitive for all factories)
-            with warnings.catch_warnings():
-                # The dict interface of entry_points is deprecated ... already
-                # and this deprecation is for us to worry about, not our users
-                warnings.simplefilter('ignore', category=DeprecationWarning)
-                group = entry_points()['gpiozero_pin_factories']
-            for ep in group:
+            for ep in PinFactory_entry_points:
                 if ep.name == name:
                     return ep.load()()
-            for ep in group:
+            for ep in PinFactory_entry_points:
                 if ep.name == name.lower():
                     return ep.load()()
             raise BadPinFactory(f'Unable to find pin factory {name!r}')

--- a/gpiozero/ep.py
+++ b/gpiozero/ep.py
@@ -1,0 +1,23 @@
+"""
+Provides access to the gpiozero entry points:
+
+.. code-block:: python
+    from gpiozero.ep import PinFactory_entry_points
+    
+    for ep in PinFactory_entry_points:
+        ...
+
+"""
+
+from importlib.metadata import entry_points
+
+#prefix _ will stop this being imported via from ep import * if anyone tries
+def _get_entry_points(group): 
+    try: #dict interface deprecated in Python 3.12
+        _entry_points = entry_points(group=group)
+    except TypeError: #selectable entrypoints only available from Python 3.10
+        _entry_points = entry_points()[group]
+    return _entry_points    
+
+PinFactory_entry_points = _get_entry_points(group='gpiozero_pin_factories')
+MockPinClass_entry_points = _get_entry_points(group='gpiozero_mock_pin_classes')

--- a/gpiozero/internal_devices.py
+++ b/gpiozero/internal_devices.py
@@ -13,7 +13,7 @@ import os
 import io
 import warnings
 import subprocess
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 
 from .devices import Device
 from .mixins import EventsMixin, event
@@ -489,8 +489,11 @@ class TimeOfDay(PolledInternalDevice):
     *start_time* and *end_time* (inclusive) which are :class:`~datetime.time`
     instances.
 
+    Note that *start_time* may be greater than *end_time*, indicating a time
+    period which crosses midnight.
+
     The following example turns on a lamp attached to an :class:`Energenie`
-    plug between 07:00AM and 08:00AM::
+    plug between 07:00AM and 08:00AM UTC::
 
         from gpiozero import TimeOfDay, Energenie
         from datetime import time
@@ -504,8 +507,35 @@ class TimeOfDay(PolledInternalDevice):
 
         pause()
 
-    Note that *start_time* may be greater than *end_time*, indicating a time
-    period which crosses midnight.
+    By default start and end times are timezone-aware UTC times. If you wish to
+    specify the time-zone for the start and/or end time you can do so when 
+    contructing the time, for example to switch on when it is office hours in 
+    both London and Los Angeles::
+
+        from gpiozero import TimeOfDay,
+        from datetime import time,
+        from zoneinfo import ZoneInfo
+
+        tz_LA = ZoneInfo('America/Los_Angeles')
+        tz_London = ZoneInfo('Europe/London')
+
+        officehours = TimeOfDay(time(8,30,tzinfo=tz_LA), time(18,00,tzinfo=tz_London))
+
+    If you would like to ignore timezones and use "local time" (whatever time
+    your Pi's internal clock says) then set `utc` to `False`. To
+    switch on during whatever your Pi thinks are local office hours::
+        
+        from gpiozero import TimeOfDay,
+        from datetime import time
+
+        officehours = TimeOfDay(time(8,30), time(18,00), utc=False)
+
+    .. note::
+        For backwards compatibility you can also select to use naive UTC times by
+        setting `utc` to `True` - this is no longer recommended,
+        instead you should leave `utc` set to `None` or explicity
+        specify `tzinfo=UTC` (`from datetime import UTC`) - both will give the
+        same result. 
 
     :param ~datetime.time start_time:
         The time from which the device will be considered active.
@@ -514,51 +544,97 @@ class TimeOfDay(PolledInternalDevice):
         The time after which the device will be considered inactive.
 
     :param bool utc:
-        If :data:`True` (the default), a naive UTC time will be used for the
-        comparison rather than a local time-zone reading.
+        If `None` (the default), UTC time will be used for the comparison. 
+        If `False` the local clock time will be use, ignoring the timezone. 
+        (If `True` a naive UTC time will be used - this is not recommended, 
+        see the note above)
 
     :type event_delay: float
     :param event_delay:
-        The number of seconds between file reads (defaults to 10 seconds).
+        The number of seconds between file reads (defaults to 5 seconds).
 
     :type pin_factory: Factory or None
     :param pin_factory:
         See :doc:`api_pins` for more information (this is an advanced feature
         which most users can ignore).
     """
-    def __init__(self, start_time, end_time, *, utc=True, event_delay=5.0,
+
+    def __init__(self, start_time, end_time, *, utc=None, event_delay=5.0,
                  pin_factory=None):
-        self._start_time = None
-        self._end_time = None
-        self._utc = True
+    
+        utc_deprecation_warning = (
+        'Using utc=True is deprecated and scheduled for removal in a future version.'
+        ' Please use tz="UTC" or provide a Timezone-Aware start and end time'
+        )
+        if utc:
+            warnings.warn(utc_deprecation_warning, DeprecationWarning)
+
+        self._aware = utc is None
+        self._utc = utc
+
         super().__init__(event_delay=event_delay, pin_factory=pin_factory)
         try:
             self._start_time = self._validate_time(start_time)
             self._end_time = self._validate_time(end_time)
             if self.start_time == self.end_time:
                 raise ValueError('end_time cannot equal start_time')
-            self._utc = utc
             self._fire_events(self.pin_factory.ticks(), self.is_active)
         except:
             self.close()
             raise
 
     def __repr__(self):
+        reprname = f'gpiozero.{self.__class__.__name__} object'
+        if self.aware:
+            reprstart = f'{self.start_time.replace(tzinfo=None)} [{self.start_time.tzinfo}]'
+            reprend = f'{self.end_time.replace(tzinfo=None)} [{self.end_time.tzinfo}]'
+            reprtz = ''
+        else:
+            reprstart = f'{self.start_time}'
+            reprend = f'{self.end_time}'
+            reprtz = f'{(" local", " UTC")[self.utc]}'
         try:
             self._check_open()
-            return (
-                f'<gpiozero.{self.__class__.__name__} object active between '
-                f'{self.start_time} and {self.end_time} '
-                f'{("local", "UTC")[self.utc]}>')
+            return f'<{reprname} active between {reprstart} and {reprend}{reprtz}>'
         except DeviceClosed:
             return super().__repr__()
 
     def _validate_time(self, value):
-        if isinstance(value, datetime):
-            value = value.time()
-        if not isinstance(value, time):
-            raise ValueError(
+        # If we have a datetime or similar we only want the time.
+        # hasattr is faster than try-except if we usually expect try to fail - and
+        # we'll probably be getting a time more often than a datetime
+        if hasattr(value, 'timetz'): 
+            value = value.timetz()
+        
+        if not self.aware:
+            try:
+                assert value.tzinfo == None
+            except AttributeError:
+                True # Want to include this branch in coverage report
+                pass # pass is excluded from coverage in setup.cfg 
+            except AssertionError:
+                raise ValueError(
+                'utc must be None if start_time or end_time contain tzinfo')
+
+        # Using try-except to cope with cases where someone has used an object
+        # that offers comparison with time but is not a subclass of time.
+        # Not relying on time's current implementation that checks for timetuple()
+        # as this may change in the future
+        if self.aware:            
+            try: # We need to be able to replace tzinfo and compare to aware time
+                value.replace(tzinfo=timezone.utc) < time(1, tzinfo=timezone.utc)
+            except (AttributeError, TypeError):
+                raise ValueError(
                 'start_time and end_time must be a datetime, or time instance')
+        else:
+            try: # We need to be able to compare to naive time
+                value < time(1)
+            except TypeError:
+                raise ValueError(
+                'start_time and end_time must be a datetime, or time instance')
+            
+        if self.aware and value.tzinfo == None: # Default to UTC
+            value = value.replace(tzinfo=timezone.utc)
         return value
 
     @property
@@ -578,10 +654,19 @@ class TimeOfDay(PolledInternalDevice):
     @property
     def utc(self):
         """
-        If :data:`True`, use a naive UTC time reading for comparison instead of
-        a local timezone reading.
+        If `None` (the default), UTC time will be used for the comparison. 
+        If `False` the local clock time will be use, ignoring the timezone. 
+        (If `True` a naive UTC time will be used - this is not recommended, 
+        see the note above)
         """
         return self._utc
+    
+    @property
+    def aware(self):
+        """
+        Whether the comparison will be performed in a timezone-aware manner
+        """
+        return self._aware
 
     @property
     def value(self):
@@ -592,11 +677,28 @@ class TimeOfDay(PolledInternalDevice):
         midnight), then this returns :data:`1` when the current time is
         greater than :attr:`start_time` or less than :attr:`end_time`.
         """
-        now = datetime.utcnow().time() if self.utc else datetime.now().time()
-        if self.start_time < self.end_time:
-            return int(self.start_time <= now <= self.end_time)
+        if self.aware:
+            # Beware - most timezone implementations in zoneinfo are only aware
+            # for datetime, not time objects.
+            # Think about DST to understand why ...
+            # So we need to get the current offset for each timezone right now
+            # and update the tzinfo. Doing it this way means we can keep the
+            # comparison simple and consistent for both aware and naive situations
+            now = datetime.now(tz=timezone.utc)
+            start_offset = now.astimezone(self.start_time.tzinfo).utcoffset()
+            end_offset = now.astimezone(self.end_time.tzinfo).utcoffset()
+            timenow = now.timetz()
+            _start_time = self.start_time.replace(tzinfo=timezone(start_offset))
+            _end_time = self.end_time.replace(tzinfo=timezone(end_offset))
         else:
-            return int(not self.end_time < now < self.start_time)
+            timenow = datetime.utcnow().time() if self.utc else datetime.now(tz=None).time()
+            _start_time = self.start_time
+            _end_time = self.end_time
+
+        if _start_time < _end_time:
+            return int(_start_time <= timenow <= _end_time)
+        else:
+            return int(not _end_time < timenow < _start_time)
 
     when_activated = event(
         """

--- a/gpiozero/pins/mock.py
+++ b/gpiozero/pins/mock.py
@@ -15,6 +15,8 @@ from threading import Thread, Event
 from math import isclose
 from importlib.metadata import entry_points
 
+from gpiozero.ep import MockPinClass_entry_points
+
 from ..exc import (
     PinPWMUnsupported,
     PinSetInput,
@@ -463,8 +465,19 @@ class MockFactory(PiFactory):
         if isinstance(pin_class, bytes):
             pin_class = pin_class.decode('ascii')
         if isinstance(pin_class, str):
-            group = entry_points()['gpiozero_mock_pin_classes']
-            pin_class = group[pin_class.lower()].load()
+            group = MockPinClass_entry_points
+            try:
+                pin_class = group[pin_class.lower()].load()
+                # This fails on python 3.9 with
+                # TypeError: tuple indices must be integers or slices, not str
+            except TypeError:
+                # This is mega-hacky but works and is only needed for 3.9 and
+                # this is the only place we access a specific point by name.
+                #
+                # If we will support 3.9 for longer, then it's probably worth
+                # providing a helper function, or some kind of wrapper around
+                # entry_points to make life easier for others coding on top of us.  
+                pin_class = [c for c in group if c.name==pin_class.lower()][0].load()
         if not issubclass(pin_class, MockPin):
             raise ValueError(f'invalid mock pin_class: {pin_class!r}')
         self.pin_class = pin_class

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,9 @@ gpiozero_mock_pin_classes =
     mocktriggerpin   = gpiozero.pins.mock:MockTriggerPin
 
 [tool:pytest]
-addopts = -rsx --cov --tb=short
+# addopts = -rsx --cov --tb=short
+# Uncomment the above line to provide basic coverage information in local runs
+# Comment out the above line to allow for debugging of tests (broken by --cov)
 testpaths = tests
 
 [coverage:run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,9 @@ from gpiozero.pins.mock import MockFactory, MockPWMPin
 if sys.version_info[:2] < (3, 4):
     warnings.simplefilter('always')
 
+# To allow @pytest.mark.xfail(condition=python_version<3.10) or similar
+python_version = sys.version_info.major + (sys.version_info.minor/100)
+
 @pytest.fixture()
 def no_default_factory(request):
     save_pin_factory = Device.pin_factory

--- a/tests/test_internal_devices.py
+++ b/tests/test_internal_devices.py
@@ -15,15 +15,19 @@ from posix import statvfs_result
 from subprocess import CalledProcessError
 from threading import Event
 from unittest import mock
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from gpiozero import *
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 
 file_not_found = IOError(errno.ENOENT, 'File not found')
 bad_ping = CalledProcessError(1, 'returned non-zero exit status 1')
 
+utc = timezone.utc
+tz_LA = ZoneInfo('America/Los_Angeles')
+tz_London = ZoneInfo('Europe/London')
 
 def test_polled_event_delay(mock_factory):
     with TimeOfDay(time(7), time(8)) as tod:
@@ -47,6 +51,48 @@ def test_timeofday_bad_init(mock_factory):
         TimeOfDay(7.00, 8.00)
     with pytest.raises(ValueError):
         TimeOfDay(datetime(2019, 1, 24, 19), time(19))  # lurch edge case
+    with pytest.deprecated_call(match='utc=True'):
+        TimeOfDay(time(7), time(8), utc=True)
+    with pytest.raises(ValueError,
+            match = 'start_time and end_time must be a datetime, or time instance'):
+        TimeOfDay('7:00', '8:00', utc=True) # edge case
+
+@pytest.mark.parametrize(
+        'args',[
+            pytest.param(
+                (time(7, tzinfo=utc), time(8)),
+                id="startaware"
+                ),
+            pytest.param(
+                (time(7), time(8,tzinfo=utc)),
+                id='endaware'
+                ),
+            pytest.param(
+                (time(7, tzinfo=tz_LA), time(8)),
+                id='startZoneInfo'
+                ),
+            pytest.param(
+                (time(7), time(8,tzinfo=tz_LA)),
+                id='endZoneInfo'
+                ),
+            ]
+        )
+@pytest.mark.parametrize(
+        'kwargs',[
+            pytest.param(
+                {'utc':True},
+                id="utcTrue"
+                ),
+            pytest.param(
+                {'utc': False},
+                id='utcFalse'
+                ),
+            ]
+        )
+def test_TimeOfDay_timezoneawaremismatch(mock_factory, args, kwargs):
+    errormessage = 'utc must be None if start_time or end_time contain tzinfo'
+    with pytest.raises(ValueError, match=errormessage):
+        TimeOfDay(*args, **kwargs)
 
 def test_timeofday_init(mock_factory):
     TimeOfDay(time(7), time(8), utc=False)
@@ -58,10 +104,48 @@ def test_timeofday_init(mock_factory):
     TimeOfDay(time(6), time(18))
     TimeOfDay(time(18), time(6))
     TimeOfDay(datetime(2019, 1, 24, 19), time(19, 1))  # lurch edge case
+    TimeOfDay(time(8,30), time(18,00), utc=False) # Documented example
 
-def test_timeofday_value(mock_factory):
+
+@pytest.mark.parametrize(
+        ('args', 'kwargs', 'start', 'end', 'aware'),[
+            pytest.param(
+                (datetime(2024,2,1,18,00,tzinfo=tz_LA), datetime(2024,2,1,23,00,tzinfo=tz_LA)),
+                {},
+                time(18,00,tzinfo=tz_LA),
+                time(23,00,tzinfo=tz_LA),
+                True,
+                id="datetime"
+                ),
+            pytest.param(
+                (time(7, tzinfo=tz_LA), time(8)),
+                {},
+                time(7,00,tzinfo=tz_LA),
+                time(8, tzinfo=utc),
+                True,
+                id='mixed-default'
+                ),
+            pytest.param(
+                (time(7, tzinfo=None), time(8, tzinfo=None)),
+                {'utc':False},
+                time(7),
+                time(8),
+                False,
+                id='local-tzinfoexplicityNone'
+                ),
+            ]
+    )
+def test_TimeOfDay_init_timezone(mock_factory, args, kwargs, start, end, aware):
+    with TimeOfDay(*args, **kwargs) as tod:
+        assert tod.start_time == start
+        assert tod.start_time.tzinfo == start.tzinfo
+        assert tod.end_time == end
+        assert tod.end_time.tzinfo == end.tzinfo
+        assert tod.aware == aware
+
+def test_TimeOfDay_naivelocal(mock_factory):
     with TimeOfDay(time(7), time(8), utc=False) as tod:
-        assert repr(tod).startswith('<gpiozero.TimeOfDay object')
+        assert repr(tod) == '<gpiozero.TimeOfDay object active between 07:00:00 and 08:00:00 local>'
         assert tod.start_time == time(7)
         assert tod.end_time == time(8)
         assert not tod.utc
@@ -74,56 +158,148 @@ def test_timeofday_value(mock_factory):
             assert tod.is_active
             dt.now.return_value = datetime(2018, 1, 2, 8, 1, 0)
             assert not tod.is_active
+            assert all([call.kwargs['tz'] == None for call in dt.mock_calls if call[0]=='now'])
     assert repr(tod) == '<gpiozero.TimeOfDay object closed>'
 
+def test_TimeOfDay_defaultUTC(mock_factory):
     with TimeOfDay(time(1, 30), time(23, 30)) as tod:
-        assert tod.start_time == time(1, 30)
-        assert tod.end_time == time(23, 30)
-        assert tod.utc
+        assert repr(tod) == '<gpiozero.TimeOfDay object active between 01:30:00 [UTC] and 23:30:00 [UTC]>'
+        assert tod.start_time == time(1, 30, tzinfo=utc)
+        assert tod.end_time == time(23, 30, tzinfo=utc)
+        assert not tod.utc
         with mock.patch('gpiozero.internal_devices.datetime') as dt:
-            dt.utcnow.return_value = datetime(2018, 1, 1, 1, 29, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 1, 29, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 1, 30, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 1, 30, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 12, 30, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 12, 30, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 23, 30, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 23, 30, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 23, 31, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 23, 31, 0, tzinfo=utc)
+            assert not tod.is_active
+            assert all([call.kwargs['tz'] == utc for call in dt.mock_calls if call[0]=='now'])
+
+def test_TimeOfDay_naiveutc(mock_factory):
+    with pytest.deprecated_call(match='utc=True'):
+        with TimeOfDay(time(7), time(8), utc=True) as tod:
+            assert repr(tod) == '<gpiozero.TimeOfDay object active between 07:00:00 and 08:00:00 UTC>'
+            assert tod.start_time == time(7, tzinfo=None)
+            assert tod.end_time == time(8, tzinfo=None)
+            assert tod.utc == True
+            with mock.patch('gpiozero.internal_devices.datetime') as dt:
+                dt.utcnow.return_value = datetime(2018, 1, 1, 6, 59, 0)
+                assert not tod.is_active
+                dt.utcnow.return_value = datetime(2018, 1, 1, 7, 0, 0)
+                assert tod.is_active
+                dt.utcnow.return_value = datetime(2018, 1, 2, 8, 0, 0)
+                assert tod.is_active
+                dt.utcnow.return_value = datetime(2018, 1, 2, 8, 1, 0)
+                assert not tod.is_active
+
+def test_TimeOfDay_tzgiven(mock_factory):
+    start = time(7, tzinfo=tz_LA)
+    end = time(8, tzinfo=tz_LA)
+    with TimeOfDay(start, end) as tod:
+        assert tod.aware == True
+        assert tod.start_time == start
+        assert tod.end_time == end
+        assert repr(tod) == '<gpiozero.TimeOfDay object active between 07:00:00 [America/Los_Angeles] and 08:00:00 [America/Los_Angeles]>'
+        with mock.patch('gpiozero.internal_devices.datetime') as dt:
+            # No DST
+            dt.now.return_value = datetime(2018, 1, 1, 7, 1, 0, tzinfo=utc) # 2017-12-31 23:01 [LA]
+            assert not tod.is_active
+            dt.now.return_value = datetime(2018, 1, 1, 14, 59, 59, tzinfo=utc) # 2018-01-01 06:59:59 [LA]
+            assert not tod.is_active
+            dt.now.return_value = datetime(2018, 1, 1, 15, 0, 0, tzinfo=utc) # 2018-01-01 07:00 [LA]
+            assert tod.is_active
+            dt.now.return_value = datetime(2018, 1, 1, 16, 0, 0, tzinfo=utc) # 2018-01-01 08:00 [LA]
+            assert tod.is_active
+            dt.now.return_value = datetime(2018, 1, 1, 16, 1, 0, tzinfo=utc) # 2018-01-01 08:01 [LA]
+            assert not tod.is_active
+            # DST
+            dt.now.return_value = datetime(2018, 8, 1, 7, 1, 0, tzinfo=utc) # 2018-08-01 00:01 [LA]
+            assert not tod.is_active
+            dt.now.return_value = datetime(2018, 8, 1, 13, 59, 59, tzinfo=utc) # 2018-08-01 06:59:59 [LA]
+            assert not tod.is_active
+            dt.now.return_value = datetime(2018, 8, 1, 14, 0, 0, tzinfo=utc) # 2018-08-01 07:00 [LA]
+            assert tod.is_active
+            dt.now.return_value = datetime(2018, 8, 1, 15, 0, 0, tzinfo=utc) # 2018-08-01 08:00 [LA]
+            assert tod.is_active
+            dt.now.return_value = datetime(2018, 8, 1, 15, 1, 0, tzinfo=utc) # 2018-08-01 08:01 [LA]
+            assert not tod.is_active
+            assert all([call.kwargs['tz'] == utc for call in dt.mock_calls if call[0]=='now'])
+
+def test_TimeOfDay_differentTZ(mock_factory):
+    with TimeOfDay(time(8,30,tzinfo=tz_LA), time(18,00,tzinfo=tz_London)) as tod:
+        assert tod.start_time == time(8,30) # LA not aware without date (DST)
+        assert tod.start_time.tzinfo == tz_LA
+        assert tod.end_time == time(18,00) # London not aware without date (DST)
+        assert tod.end_time.tzinfo == tz_London
+        assert tod.aware
+        with mock.patch('gpiozero.internal_devices.datetime') as dt:
+            # No DST
+            dt.now.return_value = datetime(2024,1,25,16,29, tzinfo=utc)
+            assert not tod.is_active
+            dt.now.return_value = datetime(2024,1,25,16,30, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,1,25,18,00, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,1,25,18,1, tzinfo=utc)
+            assert not tod.is_active
+            # LA DST
+            dt.now.return_value = datetime(2024,3,10,15,29, tzinfo=utc)
+            assert not tod.is_active
+            dt.now.return_value = datetime(2024,3,10,15,30, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,3,10,18,00, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,3,10,18,1, tzinfo=utc)
+            assert not tod.is_active
+            # Both DST
+            dt.now.return_value = datetime(2024,3,31,15,29, tzinfo=utc)
+            assert not tod.is_active
+            dt.now.return_value = datetime(2024,3,31,15,30, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,3,31,17,00, tzinfo=utc)
+            assert tod.is_active
+            dt.now.return_value = datetime(2024,3,31,17,1, tzinfo=utc)
             assert not tod.is_active
 
+def test_TimeOfDay_activeovermidnight1(mock_factory):
     with TimeOfDay(time(23), time(1)) as tod:
         with mock.patch('gpiozero.internal_devices.datetime') as dt:
-            dt.utcnow.return_value = datetime(2018, 1, 1, 22, 59, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 22, 59, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 23, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 23, 0, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 1, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 1, 0, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 1, 1, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 1, 1, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 3, 12, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 3, 12, 0, 0, tzinfo=utc)
             assert not tod.is_active
 
+def test_TimeOfDay_activeovermidnight2(mock_factory):
     with TimeOfDay(time(6), time(5)) as tod:
         with mock.patch('gpiozero.internal_devices.datetime') as dt:
-            dt.utcnow.return_value = datetime(2018, 1, 1, 5, 30, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 5, 30, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 5, 59, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 5, 59, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 6, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 6, 0, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 18, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 18, 0, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 1, 5, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 5, 0, 0, tzinfo=utc)
             assert tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 5, 1, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 5, 1, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 5, 30, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 5, 30, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 5, 59, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 5, 59, 0, tzinfo=utc)
             assert not tod.is_active
-            dt.utcnow.return_value = datetime(2018, 1, 2, 6, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 2, 6, 0, 0, tzinfo=utc)
             assert tod.is_active
 
 def test_polled_events(mock_factory):
@@ -132,17 +308,17 @@ def test_polled_events(mock_factory):
         activated = Event()
         deactivated = Event()
         with mock.patch('gpiozero.internal_devices.datetime') as dt:
-            dt.utcnow.return_value = datetime(2018, 1, 1, 0, 0, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 0, 0, 0, tzinfo=utc)
             tod._fire_events(tod.pin_factory.ticks(), tod.is_active)
             tod.when_activated = activated.set
             tod.when_deactivated = deactivated.set
             assert not activated.wait(0)
             assert not deactivated.wait(0)
-            dt.utcnow.return_value = datetime(2018, 1, 1, 7, 1, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 7, 1, 0, tzinfo=utc)
             assert activated.wait(1)
             activated.clear()
             assert not deactivated.wait(0)
-            dt.utcnow.return_value = datetime(2018, 1, 1, 8, 1, 0)
+            dt.now.return_value = datetime(2018, 1, 1, 8, 1, 0, tzinfo=utc)
             assert deactivated.wait(1)
             assert not activated.wait(0)
             tod.when_activated = None

--- a/tests/test_mock_pin.py
+++ b/tests/test_mock_pin.py
@@ -15,7 +15,6 @@ import pytest
 from gpiozero import *
 from gpiozero.pins.mock import *
 
-
 def test_mock_pin_init(mock_factory):
     with pytest.raises(ValueError):
         Device.pin_factory.pin(60)
@@ -236,3 +235,13 @@ def test_mock_charging_pin(mock_factory):
     pin.function = 'input'
     sleep(0.1)
     assert pin.state == 1
+
+def test_override_pin_class(no_default_factory):
+    factory = MockFactory(pin_class='mocktriggerpin')
+    pin16 = factory.pin(16)
+    assert isinstance(pin16, MockTriggerPin)
+
+def test_override_pin_class_capitalisation(no_default_factory):
+    factory = MockFactory(pin_class='MockTriggerPin')
+    pin16 = factory.pin(16)
+    assert isinstance(pin16, MockTriggerPin)

--- a/tests/test_pins_data.py
+++ b/tests/test_pins_data.py
@@ -90,7 +90,6 @@ def test_pi_revision():
             with pytest.raises(PinUnknownPi):
                 PiBoardInfo.from_revision(0xfff)
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_pi_info():
     r = pi_info('900011')
     assert r.model == 'B'
@@ -119,7 +118,6 @@ def test_pi_info():
     assert repr(r).startswith('PiBoardInfo(revision=')
     assert 'headers=...' in repr(r)
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_pi_info_other_types():
     assert pi_info(b'9000f1') == pi_info(0x9000f1)
 


### PR DESCRIPTION
## Background

`utcnow()` in python3.12 to reduce the danger of naive utc times being incorrectly interpreted as local times. [see the warning in the docs](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow)

The current implementation uses a flag, `utc`, in the instance to track whether the start and end times are naive utc or local time. This flag defaults to `True`.

This leads to deprecation warnings being raised which can only be dealt with in a non-thread-safe manner and collides with the future assumptions that users will make based upon the above deprecation.

## Semantics of the change

I have tried to preserve the following semantics to ensure not only tehcnical but also logical backwards compatibility:
- default handling is for times to be treated as UTC if nothing else is specified
- `utc=False` is used for specifying that times are "local time"
- specifying `utc=True` will force a naive utc, raise a custom deprecation warning to better explain the situation and allow the official warning to propogate (providing the user with full context and avoiding threading issues)
- where a timezone is given which is not a fixed offset (e.g.: a location which may observe daylight saving time) the current time in the location today, right now is used for comparison


## Additional points for discussion

1. It could be valuable to implement a new flag `local` (default: `False`) while still initially preserving the behaviour of `utc`. Given that `utc` is in future primarily used to flag local time `TimeOfDay(time(7), time(8), local=True)` would be more obvious in its intentions than `TimeOfDay(time(7), time(8), utc=False)`. This would also allow for the utc flag to be moved to a less prominent place in the documentation, the arguments order and possibly fully deprecated in v3.0.
1. When providing a `datetime` instance as a start or end time the date is ignroed and only the time element stored. This could be confusing, particularly as more use is made of the specifics of the start and end time objects, by leveraging their `tzinfo`. Any changes to this behaviour would be significantly change the semantics of the function, perhaps there is a way to allow for the user to decide whether they really mean "at this one specific point in time", or "at this time every day". It may be worth formally documenting the possibility to provide a datetime object and highlighting this behaviour. (The ability to pass a datetime object is currently undocumented but tested).

## Additional changes included
- adjustments to the validation process should now allow for substitution of datetime.datetime and datetime.time objects with others which provide the required interfaces but may not officially subclass the standard objects.
- fixes to the implementation of entry_points to ensure python3.12 compatibility. This effectively removes the need for #1112. Given that the deprecation of `utcnow`occurs in 3.12 it makes sense to include these changes here - otherwise testing in 3.12 will cause multiple tests to fail.
- adjustments the development environment to provide for virtual environments, vscode, dev containers, online code coverage analysis and running the tests on changes to every branch should contributors use these.